### PR TITLE
Added basic unit test structure

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Matrix {
     pub rows: usize,
     pub cols: usize,
@@ -247,5 +247,22 @@ fn correct(m: &mut Matrix) {
                 m.data[row][col] = 0.0;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_string() {
+        let m = Matrix::from_string("1 2 3 ; 4 5 6");
+        let expected = Matrix {
+            rows: 2,
+            cols: 3,
+            data: vec![vec![1.0, 2.0, 3.0], vec![4.0, 5.0, 6.0]],
+        };
+
+        assert!(m == expected);
     }
 }


### PR DESCRIPTION
In Rust it's common practice to add a `tests` module at the end of a file, which allows you to write localized unit tests for your code. It's expecially useful to add the `#[cfg(test)]` attribute to said module, so that it will be actually compiled only when you want to run your tests with `cargo test`. With tests correctly put in place you can delete all the prints from `main.rs` to avoid checking by yourself each result every single time.

In this specific case I derived the `PartialEq` trait for `Matrix`, which allows us to use the `==` operator between two of its instances. For such a test it would probably be better to also derive `Eq` in order to use the more specific `assert_eq!` macro, but we can't do that because the type `f64` lacks an `Eq` implementation, so you either have to implement `Eq` by hand or look for alternative ways to have a decent equality check.

You can check [this question](https://stackoverflow.com/q/26958178/9212745) for more information on the matter.