### PR TITLE
Used Clone trait instead of custom implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 use std::fs;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct Matrix {
     pub rows: usize,
     pub cols: usize,
@@ -57,18 +57,6 @@ impl Matrix {
             rows: n_r,
             cols: n_c,
             data,
-        }
-    }
-
-    pub fn copy(&self) -> Self {
-        let mut n_data: Vec<Vec<f64>> = Vec::new();
-
-        self.data.iter().for_each(|row| n_data.push(row.to_vec()));
-
-        Self {
-            rows: self.rows,
-            cols: self.cols,
-            data: n_data,
         }
     }
 
@@ -265,7 +253,6 @@ fn correct(m: &mut Matrix) {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Deriving the `Clone` trait lets you call the explicit `.clone()` method on an instance of your struct, which creates a perfect duplicate and makes it quite redundant to manually implement such functionality yourself. However, if you need to run additional code when you create a duplicate, you can implement `Clone` manually so you can do what you want (but you must check that the duplicate is actually equal to the original).

If your struct only contains fields that implement `Copy` (like primitive types that don't allocate memory on the heap) then it can also derive `Copy`, which takes effect implicitly and results in a cheap bitwise copy of the fields. `Matrix` is not such case because `Vec` doesn't implement `Copy` for reasons that are explained really well [here](https://doc.rust-lang.org/std/clone/trait.Clone.html) and [here](https://doc.rust-lang.org/std/marker/trait.Copy.html).