### PR TITLE
Used Display trait instead of custom implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use std::fs;
+use std::{fmt::Display, fs};
 
 #[derive(Debug, PartialEq)]
 pub struct Matrix {
@@ -70,11 +70,6 @@ impl Matrix {
             cols: self.cols,
             data: n_data,
         }
-    }
-
-    pub fn print(&self) {
-        self.data.iter().for_each(|v| println!("{:?}", v));
-        println!();
     }
 
     pub fn identity(&mut self) {
@@ -266,6 +261,15 @@ fn correct(m: &mut Matrix) {
     }
 }
 
+impl Display for Matrix {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for v in self.data.iter() {
+            writeln!(f, "{:?}", v)?;
+        }
+
+        Ok(())
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -281,5 +285,12 @@ mod tests {
         };
 
         assert!(m == expected);
+    }
+
+    #[test]
+    fn test_display() {
+        let m = Matrix::from_string("1 2 3 ; 4 5 6");
+        
+        assert_eq!("[1.0, 2.0, 3.0]\n[4.0, 5.0, 6.0]\n", m.to_string())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,11 +2,11 @@ use linalg::Matrix;
 
 fn main() {
     let m1 = Matrix::from_string("1 2 3 ; 4 5 6");
-    m1.print();
+    println!("{m1}");
     let m2 = Matrix::from_string("7 8 9; 10 11 12");
-    m2.print();
+    println!("{m2}");
     let m3 = m1.combine(m2, |a, b| (a * b));
-    m3.print();
+    println!("{m3}");
 
     // let mut m: Matrix = Matrix::new(3,3);
     // m.identity();


### PR DESCRIPTION
As you might have guessed, Rust is all about traits and there's a lot of them defined in the standard library to make sure a program behaves in a predictable way and exposes methods that follow an idiomatic interface. `Display` is basically `Debug`'s brother and the two are like `__str__` and `__repr__` in Python. The cool thing about `Display` is that it also gives you `.to_string()` for free, which gets called automatically when you pass an object to `print!` or `println!`.

Be sure to check out the official documentation of anything you end up encountering in Rust, because it's greatly insightful.